### PR TITLE
adds python2.7-alpine3.4 tag

### DIFF
--- a/python2.7-alpine3.4/Dockerfile
+++ b/python2.7-alpine3.4/Dockerfile
@@ -1,0 +1,56 @@
+FROM python:2.7-alpine3.4
+
+MAINTAINER Sebastian Ramirez <tiangolo@gmail.com>
+
+# Install pip dependencies
+RUN apk --no-cache add gcc libc-dev linux-headers pcre pcre-dev py-pip python3-dev
+
+# Install uWSGI
+RUN pip install uwsgi
+
+# Standard set up Nginx
+ENV NGINX_VERSION 1.12.1-r0
+
+RUN apk --no-cache add nginx ca-certificates
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+	&& ln -sf /dev/stderr /var/log/nginx/error.log
+RUN mkdir /run/nginx
+EXPOSE 80 443
+# Finished setting up Nginx
+
+# Make NGINX run on the foreground
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf
+# Copy the modified Nginx configs
+COPY nginx.conf /etc/nginx/conf.d/
+COPY root_nginx.conf /etc/nginx/nginx.conf
+# Copy the base uWSGI ini file to enable default dynamic uwsgi process number
+COPY uwsgi.ini /etc/uwsgi/
+
+# Install Supervisord
+RUN apk --no-cache add supervisor
+# Custom Supervisord config
+RUN mkdir /etc/supervisor.d
+COPY supervisord.conf /etc/supervisor.d/supervisord.ini
+
+# Which uWSGI .ini file should be used, to make it customizable
+ENV UWSGI_INI /app/uwsgi.ini
+
+# By default, allow unlimited file sizes, modify it to limit the file sizes
+# To have a maximum of 1 MB (Nginx's default) change the line to:
+# ENV NGINX_MAX_UPLOAD 1m
+ENV NGINX_MAX_UPLOAD 0
+RUN sed -i '/client_max_body_size/d' /etc/nginx/nginx.conf
+
+# Copy the entrypoint that will generate Nginx additional configs
+RUN apk --no-cache add bash
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Add demo app
+COPY ./app /app
+WORKDIR /app
+
+CMD ["/usr/bin/supervisord"]

--- a/python2.7-alpine3.4/app/main.py
+++ b/python2.7-alpine3.4/app/main.py
@@ -1,0 +1,4 @@
+def application(env, start_response):
+    start_response('200 OK', [('Content-Type', 'text/html')])
+    return ["Hello World from a default Nginx uWSGI Python 2.7 app in a\
+            Docker container (default)"]

--- a/python2.7-alpine3.4/app/uwsgi.ini
+++ b/python2.7-alpine3.4/app/uwsgi.ini
@@ -1,0 +1,2 @@
+[uwsgi]
+wsgi-file=/app/main.py

--- a/python2.7-alpine3.4/entrypoint.sh
+++ b/python2.7-alpine3.4/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+# Get the maximum upload file size for Nginx, default to 0: unlimited
+USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
+# Generate Nginx config for maximum upload file size
+echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
+
+exec "$@"

--- a/python2.7-alpine3.4/nginx.conf
+++ b/python2.7-alpine3.4/nginx.conf
@@ -1,0 +1,6 @@
+server {
+    location / {
+        include uwsgi_params;
+        uwsgi_pass unix:///tmp/uwsgi.sock;
+    }
+}

--- a/python2.7-alpine3.4/root_nginx.conf
+++ b/python2.7-alpine3.4/root_nginx.conf
@@ -1,0 +1,32 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}
+daemon off;

--- a/python2.7-alpine3.4/supervisord.conf
+++ b/python2.7-alpine3.4/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+
+[program:uwsgi]
+command=/usr/local/bin/uwsgi --ini /etc/uwsgi/uwsgi.ini --die-on-term
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:nginx]
+command=/usr/sbin/nginx
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/python2.7-alpine3.4/uwsgi.ini
+++ b/python2.7-alpine3.4/uwsgi.ini
@@ -1,0 +1,6 @@
+[uwsgi]
+socket = /tmp/uwsgi.sock
+chown-socket = nginx:nginx
+chmod-socket = 664
+cheaper = 2
+processes = 16


### PR DESCRIPTION
I created a Dockerfile based on python:2.7-alpine3.4 for use with uwsgi-nginx-flask-docker for a lighter weight image with reduced attack surface. I have this tested and running in production.

I wasn't able to get it working with python 3, but maybe someone with better alpine and/or uwsgi knowledge can bridge that gap.