### PR TITLE
Dockerfile to Python 3.5 with Alpine Linux

### DIFF
--- a/python3.5-alpine/Dockerfile
+++ b/python3.5-alpine/Dockerfile
@@ -1,9 +1,6 @@
 FROM python:3.5-alpine
 
 MAINTAINER Sebastian Ramirez <tiangolo@gmail.com>
-# CONTRIBUTOR Felipe "Prog" Esteves <progui@gmail.com>
-# Install uWSGI
-#RUN pip install uwsgi
 
 # Standard set up Nginx
 ENV NGINX_VERSION 1.12.1

--- a/python3.5-alpine/Dockerfile
+++ b/python3.5-alpine/Dockerfile
@@ -10,12 +10,13 @@ ENV NGINX_VERSION 1.12.1
 
 RUN apk update \
     && apk add --no-cache --virtual .build-deps \
-	gcc \
-	libc-dev \
-	linux-headers \
-	bash \
+    gcc \
+    libc-dev \
+    linux-headers \
+    bash \
     nginx \
-    supervisor
+    supervisor \ 
+    && rm -rf /var/cache/apk/*
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \

--- a/python3.5-alpine/Dockerfile
+++ b/python3.5-alpine/Dockerfile
@@ -1,0 +1,59 @@
+FROM python:3.5-alpine
+
+MAINTAINER Sebastian Ramirez <tiangolo@gmail.com>
+# CONTRIBUTOR Felipe "Prog" Esteves <progui@gmail.com>
+# Install uWSGI
+#RUN pip install uwsgi
+
+# Standard set up Nginx
+ENV NGINX_VERSION 1.12.1
+
+RUN apk update \
+    && apk add --no-cache --virtual .build-deps \
+	gcc \
+	libc-dev \
+	linux-headers \
+	bash \
+    nginx \
+    supervisor
+
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+	&& ln -sf /dev/stderr /var/log/nginx/error.log
+EXPOSE 80 443
+# Finished setting up Nginx
+
+# Make NGINX run on the foreground
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf
+# Remove default configuration from Nginx
+#RUN rm /etc/nginx/conf.d/default.conf
+# Copy the modified Nginx conf
+COPY nginx.conf /etc/nginx/conf.d/
+# Copy the base uWSGI ini file to enable default dynamic uwsgi process number
+COPY uwsgi.ini /etc/uwsgi/
+
+# Install Supervisord
+RUN pip install uwsgi
+
+# Custom Supervisord config
+#COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Which uWSGI .ini file should be used, to make it customizable
+ENV UWSGI_INI /app/uwsgi.ini
+
+# By default, allow unlimited file sizes, modify it to limit the file sizes
+# To have a maximum of 1 MB (Nginx's default) change the line to:
+# ENV NGINX_MAX_UPLOAD 1m
+ENV NGINX_MAX_UPLOAD 0
+
+# Copy the entrypoint that will generate Nginx additional configs
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Add demo app
+COPY ./app /app
+WORKDIR /app
+
+CMD ["/usr/bin/supervisord"]

--- a/python3.5-alpine/app/main.py
+++ b/python3.5-alpine/app/main.py
@@ -1,0 +1,4 @@
+def application(env, start_response):
+    start_response('200 OK', [('Content-Type', 'text/html')])
+    return [b"Hello World from a default Nginx uWSGI Python 3.5 app in a\
+            Docker container (default)"]

--- a/python3.5-alpine/app/uwsgi.ini
+++ b/python3.5-alpine/app/uwsgi.ini
@@ -1,0 +1,2 @@
+[uwsgi]
+wsgi-file=/app/main.py

--- a/python3.5-alpine/entrypoint.sh
+++ b/python3.5-alpine/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Get the maximum upload file size for Nginx, default to 0: unlimited
+USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
+# Generate Nginx config for maximum upload file size
+echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
+
+exec "$@"

--- a/python3.5-alpine/nginx.conf
+++ b/python3.5-alpine/nginx.conf
@@ -1,0 +1,6 @@
+server {
+    location / {
+        include uwsgi_params;
+        uwsgi_pass unix:///tmp/uwsgi.sock;
+    }
+}

--- a/python3.5-alpine/supervisord.conf
+++ b/python3.5-alpine/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+
+[program:uwsgi]
+command=/usr/local/bin/uwsgi --ini /etc/uwsgi/uwsgi.ini --die-on-term
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:nginx]
+command=/usr/sbin/nginx
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/python3.5-alpine/uwsgi.ini
+++ b/python3.5-alpine/uwsgi.ini
@@ -1,0 +1,6 @@
+[uwsgi]
+socket = /tmp/uwsgi.sock
+chown-socket = nginx:nginx
+chmod-socket = 664
+cheaper = 2
+processes = 16


### PR DESCRIPTION
Refs https://github.com/tiangolo/uwsgi-nginx-docker/issues/12

I don't know it is good enough.

It is my contrib to project.

**Docker build output**
```
$ docker build -t prog/prog/uwsgi-nginx:python3.5 .                                                           
Sending build context to Docker daemon  10.24kB
Step 1/18 : FROM python:3.5-alpine
 ---> 2070486450e1
Step 2/18 : MAINTAINER Sebastian Ramirez <tiangolo@gmail.com>
 ---> Using cache
 ---> c7337cd2bcea
Step 3/18 : ENV NGINX_VERSION 1.12.1
 ---> Using cache
 ---> eac09a54f976
Step 4/18 : RUN apk update     && apk add --no-cache --virtual .build-deps 	gcc 	libc-dev 	linux-headers 	bash     nginx     supervisor
 ---> Running in 178df59d8157
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
v3.4.6-215-g0e92484 [http://dl-cdn.alpinelinux.org/alpine/v3.4/main]
v3.4.6-160-g14ad2a3 [http://dl-cdn.alpinelinux.org/alpine/v3.4/community]
OK: 5975 distinct packages available
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/25) Installing binutils-libs (2.26-r1)
(2/25) Installing binutils (2.26-r1)
(3/25) Installing gmp (6.1.0-r0)
(4/25) Installing isl (0.14.1-r0)
(5/25) Installing libgomp (5.3.0-r0)
(6/25) Installing libatomic (5.3.0-r0)
(7/25) Installing libgcc (5.3.0-r0)
(8/25) Installing pkgconf (0.9.12-r0)
(9/25) Installing pkgconfig (0.25-r1)
(10/25) Installing mpfr3 (3.1.2-r0)
(11/25) Installing mpc1 (1.0.3-r0)
(12/25) Installing libstdc++ (5.3.0-r0)
(13/25) Installing gcc (5.3.0-r0)
(14/25) Installing musl-dev (1.1.14-r15)
(15/25) Installing libc-dev (0.7-r0)
(16/25) Installing linux-headers (4.4.6-r1)
(17/25) Installing bash (4.3.42-r5)
Executing bash-4.3.42-r5.post-install
(18/25) Installing nginx-common (1.10.3-r0)
Executing nginx-common-1.10.3-r0.pre-install
(19/25) Installing pcre (8.38-r1)
(20/25) Installing nginx (1.10.3-r0)
(21/25) Installing python (2.7.12-r0)
(22/25) Installing py-meld3 (1.0.2-r0)
(23/25) Installing py-setuptools (20.8.0-r0)
(24/25) Installing supervisor (3.2.4-r0)
(25/25) Installing .build-deps (0)
Executing busybox-1.24.2-r13.trigger
OK: 168 MiB in 59 packages
 ---> 808819c2f9e5
Removing intermediate container 178df59d8157
Step 5/18 : RUN ln -sf /dev/stdout /var/log/nginx/access.log 	&& ln -sf /dev/stderr /var/log/nginx/error.log
 ---> Running in 258f0818d447
 ---> 9871042c01c5
Removing intermediate container 258f0818d447
Step 6/18 : EXPOSE 80 443
 ---> Running in 66b11597dc9a
 ---> ffd92eb726b2
Removing intermediate container 66b11597dc9a
Step 7/18 : RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 ---> Running in 8ddadd7aac21
 ---> 56793d4e730e
Removing intermediate container 8ddadd7aac21
Step 8/18 : COPY nginx.conf /etc/nginx/conf.d/
 ---> e311037cb9f9
Removing intermediate container 6aa5a6a609a9
Step 9/18 : COPY uwsgi.ini /etc/uwsgi/
 ---> 82b451b06f38
Removing intermediate container cb3af089806a
Step 10/18 : RUN pip install uwsgi
 ---> Running in 2842068c1f5c
Collecting uwsgi
  Downloading uwsgi-2.0.15.tar.gz (795kB)
Building wheels for collected packages: uwsgi
  Running setup.py bdist_wheel for uwsgi: started
  Running setup.py bdist_wheel for uwsgi: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/26/d0/48/e7b0eed63b5d191e89d94e72196aafae93b2b6505a9feafdd9
Successfully built uwsgi
Installing collected packages: uwsgi
Successfully installed uwsgi-2.0.15
 ---> 70c2af1e501b
Removing intermediate container 2842068c1f5c
Step 11/18 : ENV UWSGI_INI /app/uwsgi.ini
 ---> Running in 67731aea4adb
 ---> 8ea15c0cbd30
Removing intermediate container 67731aea4adb
Step 12/18 : ENV NGINX_MAX_UPLOAD 0
 ---> Running in 69360047b91c
 ---> 8bbb5e36647e
Removing intermediate container 69360047b91c
Step 13/18 : COPY entrypoint.sh /entrypoint.sh
 ---> e4ef1cdd44cb
Removing intermediate container 7fed84984ee6
Step 14/18 : RUN chmod +x /entrypoint.sh
 ---> Running in aa021e61f451
 ---> f94a09d48463
Removing intermediate container aa021e61f451
Step 15/18 : ENTRYPOINT /entrypoint.sh
 ---> Running in bb9451b04a71
 ---> df8640a84b7a
Removing intermediate container bb9451b04a71
Step 16/18 : COPY ./app /app
 ---> 24aead453898
Removing intermediate container 0535094ac0e3
Step 17/18 : WORKDIR /app
 ---> 50e756491c88
Removing intermediate container 89d41908e3ff
Step 18/18 : CMD /usr/bin/supervisord
 ---> Running in 4f2759bbd059
 ---> 51a664631ed6
Removing intermediate container 4f2759bbd059
Successfully built 51a664631ed6
Successfully tagged prog/alpine-python:latest
```

**Images**
```
docker images                                                                          256ms   
REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
prog/uwsgi-nginx       python3.5           51a664631ed6        7 minutes ago       233MB
tiangolo/uwsgi-nginx   python3.5           62a94bea4e55        7 weeks ago         702MB
```