### PR TITLE
Dockerfile to Python 3.6 with Alpine Linux

### DIFF
--- a/python3.6-alpine/Dockerfile
+++ b/python3.6-alpine/Dockerfile
@@ -1,0 +1,56 @@
+FROM python:3.6-alpine
+
+MAINTAINER Sebastian Ramirez <tiangolo@gmail.com>
+
+# Standard set up Nginx
+ENV NGINX_VERSION 1.12.1
+
+RUN apk update \
+    && apk add --no-cache --virtual .build-deps \
+	gcc \
+	libc-dev \
+	linux-headers \
+	bash \
+    nginx \
+    supervisor
+
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+	&& ln -sf /dev/stderr /var/log/nginx/error.log
+EXPOSE 80 443
+# Finished setting up Nginx
+
+# Make NGINX run on the foreground
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf
+# Remove default configuration from Nginx
+#RUN rm /etc/nginx/conf.d/default.conf
+# Copy the modified Nginx conf
+COPY nginx.conf /etc/nginx/conf.d/
+# Copy the base uWSGI ini file to enable default dynamic uwsgi process number
+COPY uwsgi.ini /etc/uwsgi/
+
+# Install Supervisord
+RUN pip install uwsgi
+
+# Custom Supervisord config
+#COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Which uWSGI .ini file should be used, to make it customizable
+ENV UWSGI_INI /app/uwsgi.ini
+
+# By default, allow unlimited file sizes, modify it to limit the file sizes
+# To have a maximum of 1 MB (Nginx's default) change the line to:
+# ENV NGINX_MAX_UPLOAD 1m
+ENV NGINX_MAX_UPLOAD 0
+
+# Copy the entrypoint that will generate Nginx additional configs
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Add demo app
+COPY ./app /app
+WORKDIR /app
+
+CMD ["/usr/bin/supervisord"]

--- a/python3.6-alpine/app/main.py
+++ b/python3.6-alpine/app/main.py
@@ -1,0 +1,4 @@
+def application(env, start_response):
+    start_response('200 OK', [('Content-Type', 'text/html')])
+    return [b"Hello World from a default Nginx uWSGI Python 3.6 app in a\
+            Docker container (default)"]

--- a/python3.6-alpine/app/uwsgi.ini
+++ b/python3.6-alpine/app/uwsgi.ini
@@ -1,0 +1,2 @@
+[uwsgi]
+wsgi-file=/app/main.py

--- a/python3.6-alpine/entrypoint.sh
+++ b/python3.6-alpine/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Get the maximum upload file size for Nginx, default to 0: unlimited
+USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
+# Generate Nginx config for maximum upload file size
+echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
+
+exec "$@"

--- a/python3.6-alpine/nginx.conf
+++ b/python3.6-alpine/nginx.conf
@@ -1,0 +1,6 @@
+server {
+    location / {
+        include uwsgi_params;
+        uwsgi_pass unix:///tmp/uwsgi.sock;
+    }
+}

--- a/python3.6-alpine/supervisord.conf
+++ b/python3.6-alpine/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+
+[program:uwsgi]
+command=/usr/local/bin/uwsgi --ini /etc/uwsgi/uwsgi.ini --die-on-term
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:nginx]
+command=/usr/sbin/nginx
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/python3.6-alpine/uwsgi.ini
+++ b/python3.6-alpine/uwsgi.ini
@@ -1,0 +1,6 @@
+[uwsgi]
+socket = /tmp/uwsgi.sock
+chown-socket = nginx:nginx
+chmod-socket = 664
+cheaper = 2
+processes = 16


### PR DESCRIPTION
Same strategy another PR.
Refs https://github.com/tiangolo/uwsgi-nginx-docker/issues/11

Output
```
$ docker build -t prog/uwsgi-nginx:python3.6 .
Sending build context to Docker daemon  10.24kB
Step 1/18 : FROM python:3.6-alpine
3.6-alpine: Pulling from library/python
90f4dba627d6: Already exists 
a615e2cf13bb: Already exists 
27f6956ae76d: Pull complete 
b61bcf45b1cc: Pull complete 
ec3973580737: Pull complete 
Digest: sha256:fad0ea65ba5653242b7289a08be6cc7149f441742d9a12f74f4695963c72db76
Status: Downloaded newer image for python:3.6-alpine
 ---> d26cf7d4701d
Step 2/18 : MAINTAINER Sebastian Ramirez <tiangolo@gmail.com>
 ---> Running in a189f63eaad6
 ---> f1771991b831
Removing intermediate container a189f63eaad6
Step 3/18 : ENV NGINX_VERSION 1.12.1
 ---> Running in 6279175d1a73
 ---> 8599405d0cc7
Removing intermediate container 6279175d1a73
Step 4/18 : RUN apk update     && apk add --no-cache --virtual .build-deps 	gcc 	libc-dev 	linux-headers 	bash     nginx     supervisor
 ---> Running in e3fdfd4a8c35
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
v3.4.6-215-g0e92484 [http://dl-cdn.alpinelinux.org/alpine/v3.4/main]
v3.4.6-160-g14ad2a3 [http://dl-cdn.alpinelinux.org/alpine/v3.4/community]
OK: 5974 distinct packages available
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/25) Installing binutils-libs (2.26-r1)
(2/25) Installing binutils (2.26-r1)
(3/25) Installing gmp (6.1.0-r0)
(4/25) Installing isl (0.14.1-r0)
(5/25) Installing libgomp (5.3.0-r0)
(6/25) Installing libatomic (5.3.0-r0)
(7/25) Installing libgcc (5.3.0-r0)
(8/25) Installing pkgconf (0.9.12-r0)
(9/25) Installing pkgconfig (0.25-r1)
(10/25) Installing mpfr3 (3.1.2-r0)
(11/25) Installing mpc1 (1.0.3-r0)
(12/25) Installing libstdc++ (5.3.0-r0)
(13/25) Installing gcc (5.3.0-r0)
(14/25) Installing musl-dev (1.1.14-r15)
(15/25) Installing libc-dev (0.7-r0)
(16/25) Installing linux-headers (4.4.6-r1)
(17/25) Installing bash (4.3.42-r5)
Executing bash-4.3.42-r5.post-install
(18/25) Installing nginx-common (1.10.3-r0)
Executing nginx-common-1.10.3-r0.pre-install
(19/25) Installing pcre (8.38-r1)
(20/25) Installing nginx (1.10.3-r0)
(21/25) Installing python (2.7.12-r0)
(22/25) Installing py-meld3 (1.0.2-r0)
(23/25) Installing py-setuptools (20.8.0-r0)
(24/25) Installing supervisor (3.2.4-r0)
(25/25) Installing .build-deps (0)
Executing busybox-1.24.2-r13.trigger
OK: 168 MiB in 59 packages
 ---> e56ad63bcee1
Removing intermediate container e3fdfd4a8c35
Step 5/18 : RUN ln -sf /dev/stdout /var/log/nginx/access.log 	&& ln -sf /dev/stderr /var/log/nginx/error.log
 ---> Running in b5d8aa209969
 ---> 0498d4e1630b
Removing intermediate container b5d8aa209969
Step 6/18 : EXPOSE 80 443
 ---> Running in d298d2c8062d
 ---> fefd5c7059f1
Removing intermediate container d298d2c8062d
Step 7/18 : RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 ---> Running in 89432eb8cd42
 ---> a06563221c08
Removing intermediate container 89432eb8cd42
Step 8/18 : COPY nginx.conf /etc/nginx/conf.d/
 ---> 310ece3892eb
Removing intermediate container 6970251c3fcb
Step 9/18 : COPY uwsgi.ini /etc/uwsgi/
 ---> 067f44768ec6
Removing intermediate container c4545b51f175
Step 10/18 : RUN pip install uwsgi
 ---> Running in e6ac416df486
Collecting uwsgi
  Downloading uwsgi-2.0.15.tar.gz (795kB)
Building wheels for collected packages: uwsgi
  Running setup.py bdist_wheel for uwsgi: started
  Running setup.py bdist_wheel for uwsgi: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/26/d0/48/e7b0eed63b5d191e89d94e72196aafae93b2b6505a9feafdd9
Successfully built uwsgi
Installing collected packages: uwsgi
Successfully installed uwsgi-2.0.15
 ---> e73928ad87cb
Removing intermediate container e6ac416df486
Step 11/18 : ENV UWSGI_INI /app/uwsgi.ini
 ---> Running in b1349aebf05c
 ---> 45cdf77da34b
Removing intermediate container b1349aebf05c
Step 12/18 : ENV NGINX_MAX_UPLOAD 0
 ---> Running in 8d39b603cbf2
 ---> 14e04b678bea
Removing intermediate container 8d39b603cbf2
Step 13/18 : COPY entrypoint.sh /entrypoint.sh
 ---> 8b484ee24796
Removing intermediate container f8c5f8230e80
Step 14/18 : RUN chmod +x /entrypoint.sh
 ---> Running in 71a598fd1f60
 ---> 8103f9042179
Removing intermediate container 71a598fd1f60
Step 15/18 : ENTRYPOINT /entrypoint.sh
 ---> Running in 877a87a3bcae
 ---> 0a1abf4b5620
Removing intermediate container 877a87a3bcae
Step 16/18 : COPY ./app /app
 ---> 8766f2e6912b
Removing intermediate container a1d90385f57c
Step 17/18 : WORKDIR /app
 ---> 78b09ef0edb8
Removing intermediate container 15f99b8423f5
Step 18/18 : CMD /usr/bin/supervisord
 ---> Running in e8a05f20a0c1
 ---> c1d44fe4b11d
Removing intermediate container e8a05f20a0c1
Successfully built c1d44fe4b11d
Successfully tagged prog/uwsgi-nginx:python3.6
```

Images
```
REPOSITORY             TAG                 IMAGE ID            CREATED              SIZE
prog/uwsgi-nginx       python3.6           c1d44fe4b11d        About a minute ago   233MB
tiangolo/uwsgi-nginx   python3.6           6ef66e84f1fc        7 weeks ago          702MB
```