### PR TITLE
Python2.7 with Alpine Linux

### DIFF
--- a/python2.7-alpine/Dockerfile
+++ b/python2.7-alpine/Dockerfile
@@ -1,0 +1,56 @@
+FROM python:2.7-alpine
+
+MAINTAINER Sebastian Ramirez <tiangolo@gmail.com>
+
+# Standard set up Nginx
+ENV NGINX_VERSION 1.12.1
+
+RUN apk update \
+    && apk add --no-cache --virtual .build-deps \
+	gcc \
+	libc-dev \
+	linux-headers \
+	bash \
+    nginx \
+    supervisor
+
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+	&& ln -sf /dev/stderr /var/log/nginx/error.log
+EXPOSE 80 443
+# Finished setting up Nginx
+
+# Make NGINX run on the foreground
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf
+# Remove default configuration from Nginx
+#RUN rm /etc/nginx/conf.d/default.conf
+# Copy the modified Nginx conf
+COPY nginx.conf /etc/nginx/conf.d/
+# Copy the base uWSGI ini file to enable default dynamic uwsgi process number
+COPY uwsgi.ini /etc/uwsgi/
+
+# Install Supervisord
+RUN pip install uwsgi
+
+# Custom Supervisord config
+#COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Which uWSGI .ini file should be used, to make it customizable
+ENV UWSGI_INI /app/uwsgi.ini
+
+# By default, allow unlimited file sizes, modify it to limit the file sizes
+# To have a maximum of 1 MB (Nginx's default) change the line to:
+# ENV NGINX_MAX_UPLOAD 1m
+ENV NGINX_MAX_UPLOAD 0
+
+# Copy the entrypoint that will generate Nginx additional configs
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Add demo app
+COPY ./app /app
+WORKDIR /app
+
+CMD ["/usr/bin/supervisord"]

--- a/python2.7-alpine/Dockerfile
+++ b/python2.7-alpine/Dockerfile
@@ -7,12 +7,13 @@ ENV NGINX_VERSION 1.12.1
 
 RUN apk update \
     && apk add --no-cache --virtual .build-deps \
-	gcc \
-	libc-dev \
-	linux-headers \
-	bash \
+    gcc \
+    libc-dev \
+    linux-headers \
+    bash \
     nginx \
-    supervisor
+    supervisor \ 
+    && rm -rf /var/cache/apk/*
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \

--- a/python2.7-alpine/app/main.py
+++ b/python2.7-alpine/app/main.py
@@ -1,0 +1,4 @@
+def application(env, start_response):
+    start_response('200 OK', [('Content-Type', 'text/html')])
+    return ["Hello World from a default Nginx uWSGI Python 2.7 app in a\
+            Docker container (default)"]

--- a/python2.7-alpine/app/uwsgi.ini
+++ b/python2.7-alpine/app/uwsgi.ini
@@ -1,0 +1,2 @@
+[uwsgi]
+wsgi-file=/app/main.py

--- a/python2.7-alpine/entrypoint.sh
+++ b/python2.7-alpine/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+# Get the maximum upload file size for Nginx, default to 0: unlimited
+USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
+# Generate Nginx config for maximum upload file size
+echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
+
+exec "$@"

--- a/python2.7-alpine/nginx.conf
+++ b/python2.7-alpine/nginx.conf
@@ -1,0 +1,6 @@
+server {
+    location / {
+        include uwsgi_params;
+        uwsgi_pass unix:///tmp/uwsgi.sock;
+    }
+}

--- a/python2.7-alpine/supervisord.conf
+++ b/python2.7-alpine/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+
+[program:uwsgi]
+command=/usr/local/bin/uwsgi --ini /etc/uwsgi/uwsgi.ini --die-on-term
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:nginx]
+command=/usr/sbin/nginx
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/python2.7-alpine/uwsgi.ini
+++ b/python2.7-alpine/uwsgi.ini
@@ -1,0 +1,6 @@
+[uwsgi]
+socket = /tmp/uwsgi.sock
+chown-socket = nginx:nginx
+chmod-socket = 664
+cheaper = 2
+processes = 16

--- a/python3.6-alpine/Dockerfile
+++ b/python3.6-alpine/Dockerfile
@@ -7,12 +7,13 @@ ENV NGINX_VERSION 1.12.1
 
 RUN apk update \
     && apk add --no-cache --virtual .build-deps \
-	gcc \
-	libc-dev \
-	linux-headers \
-	bash \
+    gcc \
+    libc-dev \
+    linux-headers \
+    bash \
     nginx \
-    supervisor
+    supervisor \ 
+    && rm -rf /var/cache/apk/*
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \

--- a/python3.6-alpine/Dockerfile
+++ b/python3.6-alpine/Dockerfile
@@ -1,0 +1,56 @@
+FROM python:3.6-alpine
+
+MAINTAINER Sebastian Ramirez <tiangolo@gmail.com>
+
+# Standard set up Nginx
+ENV NGINX_VERSION 1.12.1
+
+RUN apk update \
+    && apk add --no-cache --virtual .build-deps \
+	gcc \
+	libc-dev \
+	linux-headers \
+	bash \
+    nginx \
+    supervisor
+
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+	&& ln -sf /dev/stderr /var/log/nginx/error.log
+EXPOSE 80 443
+# Finished setting up Nginx
+
+# Make NGINX run on the foreground
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf
+# Remove default configuration from Nginx
+#RUN rm /etc/nginx/conf.d/default.conf
+# Copy the modified Nginx conf
+COPY nginx.conf /etc/nginx/conf.d/
+# Copy the base uWSGI ini file to enable default dynamic uwsgi process number
+COPY uwsgi.ini /etc/uwsgi/
+
+# Install Supervisord
+RUN pip install uwsgi
+
+# Custom Supervisord config
+#COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Which uWSGI .ini file should be used, to make it customizable
+ENV UWSGI_INI /app/uwsgi.ini
+
+# By default, allow unlimited file sizes, modify it to limit the file sizes
+# To have a maximum of 1 MB (Nginx's default) change the line to:
+# ENV NGINX_MAX_UPLOAD 1m
+ENV NGINX_MAX_UPLOAD 0
+
+# Copy the entrypoint that will generate Nginx additional configs
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Add demo app
+COPY ./app /app
+WORKDIR /app
+
+CMD ["/usr/bin/supervisord"]

--- a/python3.6-alpine/app/main.py
+++ b/python3.6-alpine/app/main.py
@@ -1,0 +1,4 @@
+def application(env, start_response):
+    start_response('200 OK', [('Content-Type', 'text/html')])
+    return [b"Hello World from a default Nginx uWSGI Python 3.6 app in a\
+            Docker container (default)"]

--- a/python3.6-alpine/app/uwsgi.ini
+++ b/python3.6-alpine/app/uwsgi.ini
@@ -1,0 +1,2 @@
+[uwsgi]
+wsgi-file=/app/main.py

--- a/python3.6-alpine/entrypoint.sh
+++ b/python3.6-alpine/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Get the maximum upload file size for Nginx, default to 0: unlimited
+USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
+# Generate Nginx config for maximum upload file size
+echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
+
+exec "$@"

--- a/python3.6-alpine/nginx.conf
+++ b/python3.6-alpine/nginx.conf
@@ -1,0 +1,6 @@
+server {
+    location / {
+        include uwsgi_params;
+        uwsgi_pass unix:///tmp/uwsgi.sock;
+    }
+}

--- a/python3.6-alpine/supervisord.conf
+++ b/python3.6-alpine/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+
+[program:uwsgi]
+command=/usr/local/bin/uwsgi --ini /etc/uwsgi/uwsgi.ini --die-on-term
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:nginx]
+command=/usr/sbin/nginx
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/python3.6-alpine/uwsgi.ini
+++ b/python3.6-alpine/uwsgi.ini
@@ -1,0 +1,6 @@
+[uwsgi]
+socket = /tmp/uwsgi.sock
+chown-socket = nginx:nginx
+chmod-socket = 664
+cheaper = 2
+processes = 16


### PR DESCRIPTION
Refs https://github.com/tiangolo/uwsgi-nginx-docker/issues/10

Output
```
$ docker build -t prog/uwsgi-nginx:python2.7 .
Sending build context to Docker daemon  9.728kB
Step 1/18 : FROM python:2.7-alpine
2.7-alpine: Pulling from library/python
90f4dba627d6: Already exists 
a615e2cf13bb: Already exists 
21bec36dca7a: Pull complete 
87e78cdc890d: Pull complete 
Digest: sha256:2b1b7a67f8e93ba2fada53a189ab7b50c1cd117879ec5028996503cbf577b3d4
Status: Downloaded newer image for python:2.7-alpine
 ---> 9b06bbaac1c7
Step 2/18 : MAINTAINER Sebastian Ramirez <tiangolo@gmail.com>
 ---> Running in 46512e084675
 ---> 9bf99a38fb05
Removing intermediate container 46512e084675
Step 3/18 : ENV NGINX_VERSION 1.12.1
 ---> Running in ccf61f769615
 ---> 14518718edc5
Removing intermediate container ccf61f769615
Step 4/18 : RUN apk update     && apk add --no-cache --virtual .build-deps 	gcc 	libc-dev 	linux-headers 	bash     nginx     supervisor
 ---> Running in 9e3f474d5fc2
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
v3.4.6-215-g0e92484 [http://dl-cdn.alpinelinux.org/alpine/v3.4/main]
v3.4.6-160-g14ad2a3 [http://dl-cdn.alpinelinux.org/alpine/v3.4/community]
OK: 5975 distinct packages available
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/26) Installing binutils-libs (2.26-r1)
(2/26) Installing binutils (2.26-r1)
(3/26) Installing gmp (6.1.0-r0)
(4/26) Installing isl (0.14.1-r0)
(5/26) Installing libgomp (5.3.0-r0)
(6/26) Installing libatomic (5.3.0-r0)
(7/26) Installing libgcc (5.3.0-r0)
(8/26) Installing pkgconf (0.9.12-r0)
(9/26) Installing pkgconfig (0.25-r1)
(10/26) Installing mpfr3 (3.1.2-r0)
(11/26) Installing mpc1 (1.0.3-r0)
(12/26) Installing libstdc++ (5.3.0-r0)
(13/26) Installing gcc (5.3.0-r0)
(14/26) Installing musl-dev (1.1.14-r15)
(15/26) Installing libc-dev (0.7-r0)
(16/26) Installing linux-headers (4.4.6-r1)
(17/26) Installing bash (4.3.42-r5)
Executing bash-4.3.42-r5.post-install
(18/26) Installing nginx-common (1.10.3-r0)
Executing nginx-common-1.10.3-r0.pre-install
(19/26) Installing pcre (8.38-r1)
(20/26) Installing nginx (1.10.3-r0)
(21/26) Installing libffi (3.2.1-r2)
(22/26) Installing python (2.7.12-r0)
(23/26) Installing py-meld3 (1.0.2-r0)
(24/26) Installing py-setuptools (20.8.0-r0)
(25/26) Installing supervisor (3.2.4-r0)
(26/26) Installing .build-deps (0)
Executing busybox-1.24.2-r13.trigger
OK: 168 MiB in 58 packages
 ---> ca2b545a34e1
Removing intermediate container 9e3f474d5fc2
Step 5/18 : RUN ln -sf /dev/stdout /var/log/nginx/access.log 	&& ln -sf /dev/stderr /var/log/nginx/error.log
 ---> Running in ea0c89eec098
 ---> 9040933e1967
Removing intermediate container ea0c89eec098
Step 6/18 : EXPOSE 80 443
 ---> Running in c73f702c89f6
 ---> e26d5548f050
Removing intermediate container c73f702c89f6
Step 7/18 : RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 ---> Running in fc793172457b
 ---> a63adf866c76
Removing intermediate container fc793172457b
Step 8/18 : COPY nginx.conf /etc/nginx/conf.d/
 ---> da4d197db0c9
Removing intermediate container 7c49653a58d0
Step 9/18 : COPY uwsgi.ini /etc/uwsgi/
 ---> a416ce5d41e6
Removing intermediate container 38bc13cb5551
Step 10/18 : RUN pip install uwsgi
 ---> Running in 37f1edd3339b
Collecting uwsgi
  Downloading uwsgi-2.0.15.tar.gz (795kB)
Building wheels for collected packages: uwsgi
  Running setup.py bdist_wheel for uwsgi: started
  Running setup.py bdist_wheel for uwsgi: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/26/d0/48/e7b0eed63b5d191e89d94e72196aafae93b2b6505a9feafdd9
Successfully built uwsgi
Installing collected packages: uwsgi
Successfully installed uwsgi-2.0.15
 ---> 63e3679b844f
Removing intermediate container 37f1edd3339b
Step 11/18 : ENV UWSGI_INI /app/uwsgi.ini
 ---> Running in e827269bd7e0
 ---> 9034a093953b
Removing intermediate container e827269bd7e0
Step 12/18 : ENV NGINX_MAX_UPLOAD 0
 ---> Running in fddf68c204bd
 ---> 72b40ff1cc56
Removing intermediate container fddf68c204bd
Step 13/18 : COPY entrypoint.sh /entrypoint.sh
 ---> c1aca2c7726a
Removing intermediate container 1ac49ebab1c6
Step 14/18 : RUN chmod +x /entrypoint.sh
 ---> Running in 2867d1a1d78b
 ---> c917e3a108c4
Removing intermediate container 2867d1a1d78b
Step 15/18 : ENTRYPOINT /entrypoint.sh
 ---> Running in 1b45d138f081
 ---> 542e2ca5e99c
Removing intermediate container 1b45d138f081
Step 16/18 : COPY ./app /app
 ---> e91204292571
Removing intermediate container 98b770335c10
Step 17/18 : WORKDIR /app
 ---> 1510a963faa6
Removing intermediate container 02c37fad2fa1
Step 18/18 : CMD /usr/bin/supervisord
 ---> Running in ee9d1e16bf9f
 ---> 395601ab1dd2
Removing intermediate container ee9d1e16bf9f
Successfully built 395601ab1dd2
Successfully tagged prog/uwsgi-nginx:python2.7
```

Images
```
REPOSITORY             TAG                 IMAGE ID            CREATED              SIZE
prog/uwsgi-nginx       python2.7           395601ab1dd2        About a minute ago   217MB
tiangolo/uwsgi-nginx   python2.7           f6832fd1a197        7 weeks ago          687MB
```