### PR TITLE
Make listen port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,29 @@ ENV NGINX_MAX_UPLOAD 1m
 COPY ./app /app
 ```
 
+### Custom listen port
+
+By default, the container made from this image will listen on port 80.
+
+To change this behavior, set the `LISTEN_PORT` environemt variable.
+
+You can do that in your `Dockerfile`:
+
+```dockerfile
+# ... (snip) ...
+ENV LISTEN_PORT 8080
+# ... (snip) ...
+```
+
+Or with `-e` option of [`docker run` command](https://docs.docker.com/engine/reference/commandline/run/#options), e.g.:
+
+```bash
+docker run -e LISTEN_PORT=8080 -p 8080:8080 myimage
+```
+
 ## What's new
+
+* 2017-10-XX: Now you can configure which port the container should listen on, using the environment variable `LISTEN_PORT`.
 
 * 2017-08-09: You can set a custom maximum upload file size using an environment variable `NGINX_MAX_UPLOAD`, by default it has a value of `0`, that allows unlimited upload file sizes. This differs from Nginx's default value of 1 MB. It's configured this way because that's the simplest experience a developer that is not expert in Nginx would expect.
 

--- a/latest/entrypoint.sh
+++ b/latest/entrypoint.sh
@@ -6,6 +6,11 @@ USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
 # Generate Nginx config for maximum upload file size
 echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
+# Get the listen port for Nginx, default to 80
+USE_LISTEN_PORT=${LISTEN_PORT:-80}
+# Modify Nignx config for listen port
+sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf
+
 echo -e "WARNING: YOU SHOULDN'T BE USING THE 'latest' DOCKER TAG.
 
 The Docker tag 'latest' will be for Python 3.6 soon.

--- a/python2.7/Dockerfile
+++ b/python2.7/Dockerfile
@@ -41,6 +41,11 @@ ENV UWSGI_INI /app/uwsgi.ini
 # ENV NGINX_MAX_UPLOAD 1m
 ENV NGINX_MAX_UPLOAD 0
 
+# By default, Nginx listens on port 80.
+# To modify this, change LISTEN_PORT environment variable.
+# (in a Dockerfile or with an option for `docker run`)
+ENV LISTEN_PORT 80
+
 # Copy the entrypoint that will generate Nginx additional configs
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/python2.7/entrypoint.sh
+++ b/python2.7/entrypoint.sh
@@ -5,4 +5,9 @@ USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
 # Generate Nginx config for maximum upload file size
 echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
+# Get the listen port for Nginx, default to 80
+USE_LISTEN_PORT=${LISTEN_PORT:-80}
+# Modify Nignx config for listen port
+sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf
+
 exec "$@"

--- a/python3.5/Dockerfile
+++ b/python3.5/Dockerfile
@@ -41,6 +41,11 @@ ENV UWSGI_INI /app/uwsgi.ini
 # ENV NGINX_MAX_UPLOAD 1m
 ENV NGINX_MAX_UPLOAD 0
 
+# By default, Nginx listens on port 80.
+# To modify this, change LISTEN_PORT environment variable.
+# (in a Dockerfile or with an option for `docker run`)
+ENV LISTEN_PORT 80
+
 # Copy the entrypoint that will generate Nginx additional configs
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/python3.5/entrypoint.sh
+++ b/python3.5/entrypoint.sh
@@ -6,4 +6,9 @@ USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
 # Generate Nginx config for maximum upload file size
 echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
+# Get the listen port for Nginx, default to 80
+USE_LISTEN_PORT=${LISTEN_PORT:-80}
+# Modify Nignx config for listen port
+sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf
+
 exec "$@"

--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -41,6 +41,11 @@ ENV UWSGI_INI /app/uwsgi.ini
 # ENV NGINX_MAX_UPLOAD 1m
 ENV NGINX_MAX_UPLOAD 0
 
+# By default, Nginx listens on port 80.
+# To modify this, change LISTEN_PORT environment variable.
+# (in a Dockerfile or with an option for `docker run`)
+ENV LISTEN_PORT 80
+
 # Copy the entrypoint that will generate Nginx additional configs
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/python3.6/entrypoint.sh
+++ b/python3.6/entrypoint.sh
@@ -6,4 +6,9 @@ USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
 # Generate Nginx config for maximum upload file size
 echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
+# Get the listen port for Nginx, default to 80
+USE_LISTEN_PORT=${LISTEN_PORT:-80}
+# Modify Nignx config for listen port
+sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf
+
 exec "$@"


### PR DESCRIPTION
As described in README, I made listen port configurable.
Default port is still 80, so it's backward compatible ;)

This is useful when used with Google App Engine, which require containers to listen on 8080.

https://cloud.google.com/appengine/docs/flexible/custom-runtimes/build?hl=ja#listen_to_port_8080

I'm planning to send  a pr to https://github.com/tiangolo/uwsgi-nginx-flask-docker too.