### PR TITLE
fix multiple listen entries in AWS eb

### DIFF
--- a/python2.7/entrypoint.sh
+++ b/python2.7/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+
 # Get the maximum upload file size for Nginx, default to 0: unlimited
 USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
 # Generate Nginx config for maximum upload file size
@@ -8,6 +9,7 @@ echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.co
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 # Modify Nignx config for listen port
-sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf
-
+if ! grep -q "listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf ; then
+    sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf
+fi
 exec "$@"

--- a/python3.5/entrypoint.sh
+++ b/python3.5/entrypoint.sh
@@ -9,6 +9,7 @@ echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.co
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 # Modify Nignx config for listen port
-sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf
-
+if ! grep -q "listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf ; then
+    sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf
+fi
 exec "$@"

--- a/python3.6/entrypoint.sh
+++ b/python3.6/entrypoint.sh
@@ -9,7 +9,7 @@ echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.co
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 # Modify Nignx config for listen port
-if ! grep -q 'listen ${USE_LISTEN_PORT};' /etc/nginx/conf.d/nginx.conf ; then
-	sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf
+if ! grep -q "listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf ; then
+    sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf
 fi
 exec "$@"

--- a/python3.6/entrypoint.sh
+++ b/python3.6/entrypoint.sh
@@ -9,6 +9,7 @@ echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.co
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 # Modify Nignx config for listen port
-sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf
-
+if ! grep -q 'listen ${USE_LISTEN_PORT};' /etc/nginx/conf.d/nginx.conf ; then
+	sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf
+fi
 exec "$@"


### PR DESCRIPTION
We where seeing multiple `listen 80;` entries inside our AWS ElasticBeanstalk containers after restarts. 
e.g: 
```
server {
    listen 80;
    listen 80;
    location / {
        include uwsgi_params;
        uwsgi_pass unix:///tmp/uwsgi.sock;
    }

```

This seems to be the fix.

