### PR TITLE
uWSGI runs on root so drop privileges

### DIFF
--- a/python3.6/supervisord.conf
+++ b/python3.6/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:uwsgi]
-command=/usr/local/bin/uwsgi --ini /etc/uwsgi/uwsgi.ini --die-on-term
+command=/usr/local/bin/uwsgi --ini /etc/uwsgi/uwsgi.ini --die-on-term --uid
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
having seen `*** WARNING: you are running uWSGI as root !!! (use the --uid flag) ***` in my logs I did some research and found that http://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html explains the necessity for the `--uid` flag (among other tips)