### PR TITLE
The number of Nginx worker processes can be set via an environment variable

### DIFF
--- a/python2.7-alpine3.7/Dockerfile
+++ b/python2.7-alpine3.7/Dockerfile
@@ -170,6 +170,10 @@ ENV UWSGI_INI /app/uwsgi.ini
 ENV NGINX_MAX_UPLOAD 1m
 ENV NGINX_MAX_UPLOAD 0
 
+# By default, Nginx will run a single worker process, setting it to auto
+# will create a worker for each CPU core
+ENV NGINX_WORKER_PROCESSES 1
+
 # By default, Nginx listens on port 80.
 # To modify this, change LISTEN_PORT environment variable.
 # (in a Dockerfile or with an option for `docker run`)

--- a/python2.7-alpine3.7/entrypoint.sh
+++ b/python2.7-alpine3.7/entrypoint.sh
@@ -6,14 +6,18 @@ USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
 # Generate Nginx config for maximum upload file size
 echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
-# Get the listen port for Nginx, default to 80
-USE_LISTEN_PORT=${LISTEN_PORT:-80}
-
 # Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
 # Otherwise uWSGI can't import Flask
 export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/site-packages:/usr/lib/python2.7/site-packages
 
-# Modify Nignx config for listen port
+# Get the number of workers for Nginx, default to 1
+USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
+# Modify the number of worker processes in Nginx config
+sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
+
+# Get the listen port for Nginx, default to 80
+USE_LISTEN_PORT=${LISTEN_PORT:-80}
+# Modify Nginx config for listen port
 if ! grep -q "listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf ; then
     sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf
 fi

--- a/python2.7/Dockerfile
+++ b/python2.7/Dockerfile
@@ -41,6 +41,10 @@ ENV UWSGI_INI /app/uwsgi.ini
 # ENV NGINX_MAX_UPLOAD 1m
 ENV NGINX_MAX_UPLOAD 0
 
+# By default, Nginx will run a single worker process, setting it to auto
+# will create a worker for each CPU core
+ENV NGINX_WORKER_PROCESSES 1
+
 # By default, Nginx listens on port 80.
 # To modify this, change LISTEN_PORT environment variable.
 # (in a Dockerfile or with an option for `docker run`)

--- a/python2.7/entrypoint.sh
+++ b/python2.7/entrypoint.sh
@@ -6,6 +6,11 @@ USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
 # Generate Nginx config for maximum upload file size
 echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
+# Get the number of workers for Nginx, default to 1
+USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
+# Modify the number of worker processes in Nginx config
+sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
+
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 # Modify Nignx config for listen port

--- a/python3.5/Dockerfile
+++ b/python3.5/Dockerfile
@@ -41,6 +41,10 @@ ENV UWSGI_INI /app/uwsgi.ini
 # ENV NGINX_MAX_UPLOAD 1m
 ENV NGINX_MAX_UPLOAD 0
 
+# By default, Nginx will run a single worker process, setting it to auto
+# will create a worker for each CPU core
+ENV NGINX_WORKER_PROCESSES 1
+
 # By default, Nginx listens on port 80.
 # To modify this, change LISTEN_PORT environment variable.
 # (in a Dockerfile or with an option for `docker run`)

--- a/python3.5/entrypoint.sh
+++ b/python3.5/entrypoint.sh
@@ -6,6 +6,11 @@ USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
 # Generate Nginx config for maximum upload file size
 echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
+# Get the number of workers for Nginx, default to 1
+USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
+# Modify the number of worker processes in Nginx config
+sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
+
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 # Modify Nignx config for listen port

--- a/python3.6-alpine3.7/Dockerfile
+++ b/python3.6-alpine3.7/Dockerfile
@@ -170,6 +170,10 @@ ENV UWSGI_INI /app/uwsgi.ini
 ENV NGINX_MAX_UPLOAD 1m
 ENV NGINX_MAX_UPLOAD 0
 
+# By default, Nginx will run a single worker process, setting it to auto
+# will create a worker for each CPU core
+ENV NGINX_WORKER_PROCESSES 1
+
 # By default, Nginx listens on port 80.
 # To modify this, change LISTEN_PORT environment variable.
 # (in a Dockerfile or with an option for `docker run`)

--- a/python3.6-alpine3.7/entrypoint.sh
+++ b/python3.6-alpine3.7/entrypoint.sh
@@ -6,13 +6,17 @@ USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
 # Generate Nginx config for maximum upload file size
 echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
-# Get the listen port for Nginx, default to 80
-USE_LISTEN_PORT=${LISTEN_PORT:-80}
-
 # Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
 # Otherwise uWSGI can't import Flask
 export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.6/site-packages:/usr/lib/python3.6/site-packages
 
+# Get the number of workers for Nginx, default to 1
+USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
+# Modify the number of worker processes in Nginx config
+sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
+
+# Get the listen port for Nginx, default to 80
+USE_LISTEN_PORT=${LISTEN_PORT:-80}
 # Modify Nignx config for listen port
 if ! grep -q "listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf ; then
     sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf

--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -123,6 +123,10 @@ ENV UWSGI_INI /app/uwsgi.ini
 # ENV NGINX_MAX_UPLOAD 1m
 ENV NGINX_MAX_UPLOAD 0
 
+# By default, Nginx will run a single worker process, setting it to auto
+# will create a worker for each CPU core
+ENV NGINX_WORKER_PROCESSES 1
+
 # By default, Nginx listens on port 80.
 # To modify this, change LISTEN_PORT environment variable.
 # (in a Dockerfile or with an option for `docker run`)

--- a/python3.6/entrypoint.sh
+++ b/python3.6/entrypoint.sh
@@ -6,6 +6,11 @@ USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
 # Generate Nginx config for maximum upload file size
 echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
+# Get the number of workers for Nginx, default to 1
+USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
+# Modify the number of worker processes in Nginx config
+sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
+
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 # Modify Nignx config for listen port


### PR DESCRIPTION
The value is set in a `Dockerfile` and written to the configuration in the `entrypoint.sh` script with a `sed` command that replaces the entire line.