### PR TITLE
Graceful shutdown nginx and uwsgi

### DIFF
--- a/python2.7-alpine3.7/supervisord.ini
+++ b/python2.7-alpine3.7/supervisord.ini
@@ -14,3 +14,5 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+# Graceful stop, see http://nginx.org/en/docs/control.html
+stopsignal=QUIT

--- a/python2.7-alpine3.7/uwsgi.ini
+++ b/python2.7-alpine3.7/uwsgi.ini
@@ -2,5 +2,5 @@
 socket = /tmp/uwsgi.sock
 chown-socket = nginx:nginx
 chmod-socket = 664
-# Graceful shutdown on SIGTERM
+# Graceful shutdown on SIGTERM, see https://github.com/unbit/uwsgi/issues/849#issuecomment-118869386
 hook-master-start = unix_signal:15 gracefully_kill_them_all

--- a/python2.7-alpine3.7/uwsgi.ini
+++ b/python2.7-alpine3.7/uwsgi.ini
@@ -2,3 +2,5 @@
 socket = /tmp/uwsgi.sock
 chown-socket = nginx:nginx
 chmod-socket = 664
+# Graceful shutdown on SIGTERM
+hook-master-start = unix_signal:15 gracefully_kill_them_all

--- a/python2.7/supervisord.conf
+++ b/python2.7/supervisord.conf
@@ -14,3 +14,5 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+# Graceful stop, see http://nginx.org/en/docs/control.html
+stopsignal=QUIT

--- a/python2.7/uwsgi.ini
+++ b/python2.7/uwsgi.ini
@@ -2,5 +2,5 @@
 socket = /tmp/uwsgi.sock
 chown-socket = nginx:nginx
 chmod-socket = 664
-# Graceful shutdown on SIGTERM
+# Graceful shutdown on SIGTERM, see https://github.com/unbit/uwsgi/issues/849#issuecomment-118869386
 hook-master-start = unix_signal:15 gracefully_kill_them_all

--- a/python2.7/uwsgi.ini
+++ b/python2.7/uwsgi.ini
@@ -2,3 +2,5 @@
 socket = /tmp/uwsgi.sock
 chown-socket = nginx:nginx
 chmod-socket = 664
+# Graceful shutdown on SIGTERM
+hook-master-start = unix_signal:15 gracefully_kill_them_all

--- a/python3.5/supervisord.conf
+++ b/python3.5/supervisord.conf
@@ -14,3 +14,5 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+# Graceful stop, see http://nginx.org/en/docs/control.html
+stopsignal=QUIT

--- a/python3.5/uwsgi.ini
+++ b/python3.5/uwsgi.ini
@@ -2,5 +2,5 @@
 socket = /tmp/uwsgi.sock
 chown-socket = nginx:nginx
 chmod-socket = 664
-# Graceful shutdown on SIGTERM
+# Graceful shutdown on SIGTERM, see https://github.com/unbit/uwsgi/issues/849#issuecomment-118869386
 hook-master-start = unix_signal:15 gracefully_kill_them_all

--- a/python3.5/uwsgi.ini
+++ b/python3.5/uwsgi.ini
@@ -2,3 +2,5 @@
 socket = /tmp/uwsgi.sock
 chown-socket = nginx:nginx
 chmod-socket = 664
+# Graceful shutdown on SIGTERM
+hook-master-start = unix_signal:15 gracefully_kill_them_all

--- a/python3.6-alpine3.7/supervisord.ini
+++ b/python3.6-alpine3.7/supervisord.ini
@@ -14,3 +14,5 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+# Graceful stop, see http://nginx.org/en/docs/control.html
+stopsignal=QUIT

--- a/python3.6-alpine3.7/uwsgi.ini
+++ b/python3.6-alpine3.7/uwsgi.ini
@@ -2,5 +2,5 @@
 socket = /tmp/uwsgi.sock
 chown-socket = nginx:nginx
 chmod-socket = 664
-# Graceful shutdown on SIGTERM
+# Graceful shutdown on SIGTERM, see https://github.com/unbit/uwsgi/issues/849#issuecomment-118869386
 hook-master-start = unix_signal:15 gracefully_kill_them_all

--- a/python3.6-alpine3.7/uwsgi.ini
+++ b/python3.6-alpine3.7/uwsgi.ini
@@ -2,3 +2,5 @@
 socket = /tmp/uwsgi.sock
 chown-socket = nginx:nginx
 chmod-socket = 664
+# Graceful shutdown on SIGTERM
+hook-master-start = unix_signal:15 gracefully_kill_them_all

--- a/python3.6/supervisord.conf
+++ b/python3.6/supervisord.conf
@@ -14,3 +14,5 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+# Graceful stop, see http://nginx.org/en/docs/control.html
+stopsignal=QUIT

--- a/python3.6/uwsgi.ini
+++ b/python3.6/uwsgi.ini
@@ -2,5 +2,5 @@
 socket = /tmp/uwsgi.sock
 chown-socket = nginx:nginx
 chmod-socket = 664
-# Graceful shutdown on SIGTERM
+# Graceful shutdown on SIGTERM, see https://github.com/unbit/uwsgi/issues/849#issuecomment-118869386
 hook-master-start = unix_signal:15 gracefully_kill_them_all

--- a/python3.6/uwsgi.ini
+++ b/python3.6/uwsgi.ini
@@ -2,3 +2,5 @@
 socket = /tmp/uwsgi.sock
 chown-socket = nginx:nginx
 chmod-socket = 664
+# Graceful shutdown on SIGTERM
+hook-master-start = unix_signal:15 gracefully_kill_them_all


### PR DESCRIPTION
Currently, when the container is stopped, supervisor sends a SIGTERM signal to both nginx and uwsgi.

By default, on nginx, it causes a fast shutdown (not honoring open requests), and on uwsgi it causes a brutal kill of all workers.

This PR makes supervisor send a SIGQUIT to nginx (graceful stop), and add a built-in handler in uwsgi to gracefully stop workers.

Results: no more errors when doing a kubernetes rolling-release for servers with frequent long-requests.

Caveats: you need "master" mode in uwsgi to be enabled (true by default).