### PR TITLE
Add Travis, for continuous building error checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 
+language: python
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+- bash scripts/test.sh

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  python2.7:
+    build: ./python2.7
+  python2.7-alpine3.7:
+    build: ./python2.7-alpine3.7
+  python2.7-alpine3.8:
+    build: ./python2.7-alpine3.8
+  python3.5:
+    build: ./python3.5
+  python3.6:
+    build: ./python3.6
+  python3.6-alpine3.7:
+    build: ./python3.6-alpine3.7
+  python3.6-alpine3.8:
+    build: ./python3.6-alpine3.8
+  python3.7:
+    build: ./python3.7
+  python3.7-alpine3.7:
+    build: ./python3.7-alpine3.7
+  python3.7-alpine3.8:
+    build: ./python3.7-alpine3.8

--- a/python2.7/Dockerfile
+++ b/python2.7/Dockerfile
@@ -5,8 +5,8 @@ LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 RUN pip install uwsgi
 
 # Standard set up Nginx
-ENV NGINX_VERSION 1.13.12-1~stretch
-ENV NJS_VERSION   1.13.12.0.2.0-1~stretch
+ENV NGINX_VERSION 1.15.8-1~stretch
+ENV NJS_VERSION   1.15.8.0.2.7-1~stretch
 
 RUN set -x \
 	&& apt-get update \
@@ -21,7 +21,7 @@ RUN set -x \
 		pgp.mit.edu \
 	; do \
 		echo "Fetching GPG key $NGINX_GPGKEY from $server"; \
-		apt-key adv --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
+		apt-key adv --no-tty --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
 	done; \
 	test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
 	apt-get remove --purge --auto-remove -y gnupg1 && rm -rf /var/lib/apt/lists/* \
@@ -96,7 +96,9 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log
 EXPOSE 80
 # Removed the section that breaks pip installations
-# && apt-get remove --purge --auto-remove -y apt-transport-https ca-certificates 
+# && apt-get remove --purge --auto-remove -y apt-transport-https ca-certificates
+# added --no-tty to apt-key adv as without it it breaks (even though it works in official Nginx)
+# apt-key adv --no-tty
 # Standard set up Nginx finished
 
 # Expose 443, in case of LTS / HTTPS

--- a/python3.5/Dockerfile
+++ b/python3.5/Dockerfile
@@ -6,8 +6,8 @@ LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 RUN pip install uwsgi
 
 # Standard set up Nginx
-ENV NGINX_VERSION 1.13.12-1~stretch
-ENV NJS_VERSION   1.13.12.0.2.0-1~stretch
+ENV NGINX_VERSION 1.15.8-1~stretch
+ENV NJS_VERSION   1.15.8.0.2.7-1~stretch
 
 RUN set -x \
 	&& apt-get update \
@@ -22,7 +22,7 @@ RUN set -x \
 		pgp.mit.edu \
 	; do \
 		echo "Fetching GPG key $NGINX_GPGKEY from $server"; \
-		apt-key adv --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
+		apt-key adv --no-tty --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
 	done; \
 	test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
 	apt-get remove --purge --auto-remove -y gnupg1 && rm -rf /var/lib/apt/lists/* \
@@ -97,7 +97,9 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log
 EXPOSE 80
 # Removed the section that breaks pip installations
-# && apt-get remove --purge --auto-remove -y apt-transport-https ca-certificates 
+# && apt-get remove --purge --auto-remove -y apt-transport-https ca-certificates
+# added --no-tty to apt-key adv as without it it breaks (even though it works in official Nginx)
+# apt-key adv --no-tty
 # Standard set up Nginx finished
 
 # Make NGINX run on the foreground

--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -3,8 +3,8 @@ FROM python:3.6-stretch
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 # Standard set up Nginx
-ENV NGINX_VERSION 1.13.12-1~stretch
-ENV NJS_VERSION   1.13.12.0.2.0-1~stretch
+ENV NGINX_VERSION 1.15.8-1~stretch
+ENV NJS_VERSION   1.15.8.0.2.7-1~stretch
 
 RUN set -x \
 	&& apt-get update \
@@ -19,7 +19,7 @@ RUN set -x \
 		pgp.mit.edu \
 	; do \
 		echo "Fetching GPG key $NGINX_GPGKEY from $server"; \
-		apt-key adv --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
+		apt-key adv --no-tty --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
 	done; \
 	test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
 	apt-get remove --purge --auto-remove -y gnupg1 && rm -rf /var/lib/apt/lists/* \
@@ -94,7 +94,9 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log
 EXPOSE 80
 # Removed the section that breaks pip installations
-# && apt-get remove --purge --auto-remove -y apt-transport-https ca-certificates 
+# && apt-get remove --purge --auto-remove -y apt-transport-https ca-certificates
+# added --no-tty to apt-key adv as without it it breaks (even though it works in official Nginx)
+# apt-key adv --no-tty
 # Standard set up Nginx finished
 
 # Expose 443, in case of LTS / HTTPS

--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -3,8 +3,8 @@ FROM python:3.7-stretch
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 # Standard set up Nginx
-ENV NGINX_VERSION 1.13.12-1~stretch
-ENV NJS_VERSION   1.13.12.0.2.0-1~stretch
+ENV NGINX_VERSION 1.15.8-1~stretch
+ENV NJS_VERSION   1.15.8.0.2.7-1~stretch
 
 RUN set -x \
 	&& apt-get update \
@@ -19,7 +19,7 @@ RUN set -x \
 		pgp.mit.edu \
 	; do \
 		echo "Fetching GPG key $NGINX_GPGKEY from $server"; \
-		apt-key adv --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
+		apt-key adv --no-tty --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
 	done; \
 	test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
 	apt-get remove --purge --auto-remove -y gnupg1 && rm -rf /var/lib/apt/lists/* \
@@ -94,7 +94,9 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log
 EXPOSE 80
 # Removed the section that breaks pip installations
-# && apt-get remove --purge --auto-remove -y apt-transport-https ca-certificates 
+# && apt-get remove --purge --auto-remove -y apt-transport-https ca-certificates
+# added --no-tty to apt-key adv as without it it breaks (even though it works in official Nginx)
+# apt-key adv --no-tty
 # Standard set up Nginx finished
 
 # Expose 443, in case of LTS / HTTPS

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker-compose build

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
-docker-compose build
+set -e
+
+docker-compose -f docker-compose.build.yml build


### PR DESCRIPTION
Add Travis, for continuous building error checks.

Using Docker Compose to build the images.

Testing can be added on top of this.