### PR TITLE
Implement python3.8 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
   - NAME='python3.7-alpine3.7' BUILD_PATH='python3.7-alpine3.7' TEST_STR1='Hello World from a default Nginx uWSGI Python 3.7 app in a Docker container in Alpine (default)' TEST_STR2='Hello World from Nginx uWSGI Python 3.7 app in a Docker container' RUN_TESTS=''
   - NAME='python3.7-alpine3.8' BUILD_PATH='python3.7-alpine3.8' TEST_STR1='Hello World from a default Nginx uWSGI Python 3.7 app in a Docker container in Alpine (default)' TEST_STR2='Hello World from Nginx uWSGI Python 3.7 app in a Docker container' RUN_TESTS=''
   - NAME='python3.7-alpine3.9' BUILD_PATH='python3.7-alpine3.9' TEST_STR1='Hello World from a default Nginx uWSGI Python 3.7 app in a Docker container in Alpine (default)' TEST_STR2='Hello World from Nginx uWSGI Python 3.7 app in a Docker container' RUN_TESTS=''
+  - NAME='python3.8' BUILD_PATH='python3.8' TEST_STR1='Hello World from a default Nginx uWSGI Python 3.8 app in a Docker container (default)' TEST_STR2='Hello World from Nginx uWSGI Python 3.8 app in a Docker container' RUN_TESTS='1'
 
 script: bash scripts/test.sh
 

--- a/python3.8/Dockerfile
+++ b/python3.8/Dockerfile
@@ -1,0 +1,158 @@
+FROM python:3.8
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+# Standard set up Nginx
+ENV NGINX_VERSION 1.17.8-1~buster
+ENV NJS_VERSION   1.17.8.0.3.8-1~buster
+
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install --no-install-recommends --no-install-suggests -y gnupg1 apt-transport-https ca-certificates \
+	&& \
+	NGINX_GPGKEY=573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62; \
+	found=''; \
+	for server in \
+		ha.pool.sks-keyservers.net \
+		hkp://keyserver.ubuntu.com:80 \
+		hkp://p80.pool.sks-keyservers.net:80 \
+		pgp.mit.edu \
+	; do \
+		echo "Fetching GPG key $NGINX_GPGKEY from $server"; \
+		apt-key adv --no-tty --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
+	done; \
+	test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
+	apt-get remove --purge --auto-remove -y gnupg1 && rm -rf /var/lib/apt/lists/* \
+	&& dpkgArch="$(dpkg --print-architecture)" \
+	&& nginxPackages=" \
+		nginx=${NGINX_VERSION} \
+		nginx-module-xslt=${NGINX_VERSION} \
+		nginx-module-geoip=${NGINX_VERSION} \
+		nginx-module-image-filter=${NGINX_VERSION} \
+		nginx-module-njs=${NJS_VERSION} \
+	" \
+	&& case "$dpkgArch" in \
+		amd64|i386) \
+# arches officialy built by upstream
+			echo "deb https://nginx.org/packages/mainline/debian/ buster nginx" >> /etc/apt/sources.list.d/nginx.list \
+			&& apt-get update \
+			;; \
+		*) \
+# we're on an architecture upstream doesn't officially build for
+# let's build binaries from the published source packages
+			echo "deb-src https://nginx.org/packages/mainline/debian/ buster nginx" >> /etc/apt/sources.list.d/nginx.list \
+			\
+# new directory for storing sources and .deb files
+			&& tempDir="$(mktemp -d)" \
+			&& chmod 777 "$tempDir" \
+# (777 to ensure APT's "_apt" user can access it too)
+			\
+# save list of currently-installed packages so build dependencies can be cleanly removed later
+			&& savedAptMark="$(apt-mark showmanual)" \
+			\
+# build .deb files from upstream's source packages (which are verified by apt-get)
+			&& apt-get update \
+			&& apt-get build-dep -y $nginxPackages \
+			&& ( \
+				cd "$tempDir" \
+				&& DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)" \
+					apt-get source --compile $nginxPackages \
+			) \
+# we don't remove APT lists here because they get re-downloaded and removed later
+			\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+# (which is done after we install the built packages so we don't have to redownload any overlapping dependencies)
+			&& apt-mark showmanual | xargs apt-mark auto > /dev/null \
+			&& { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \
+			\
+# create a temporary local APT repo to install from (so that dependency resolution can be handled by APT, as it should be)
+			&& ls -lAFh "$tempDir" \
+			&& ( cd "$tempDir" && dpkg-scanpackages . > Packages ) \
+			&& grep '^Package: ' "$tempDir/Packages" \
+			&& echo "deb [ trusted=yes ] file://$tempDir ./" > /etc/apt/sources.list.d/temp.list \
+# work around the following APT issue by using "Acquire::GzipIndexes=false" (overriding "/etc/apt/apt.conf.d/docker-gzip-indexes")
+#   Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+#   ...
+#   E: Failed to fetch store:/var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages  Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+			&& apt-get -o Acquire::GzipIndexes=false update \
+			;; \
+	esac \
+	\
+	&& apt-get install --no-install-recommends --no-install-suggests -y \
+						$nginxPackages \
+						gettext-base \
+	&& rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list \
+	\
+# if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
+	&& if [ -n "$tempDir" ]; then \
+		apt-get purge -y --auto-remove \
+		&& rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
+	fi
+
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+	&& ln -sf /dev/stderr /var/log/nginx/error.log
+EXPOSE 80
+# Removed the section that breaks pip installations
+# && apt-get remove --purge --auto-remove -y apt-transport-https ca-certificates
+# added --no-tty to apt-key adv as without it it breaks (even though it works in official Nginx)
+# apt-key adv --no-tty
+# Standard set up Nginx finished
+
+# Expose 443, in case of LTS / HTTPS
+EXPOSE 443
+
+# Install uWSGI
+RUN pip install uwsgi
+
+# Remove default configuration from Nginx
+RUN rm /etc/nginx/conf.d/default.conf
+# Copy the base uWSGI ini file to enable default dynamic uwsgi process number
+COPY uwsgi.ini /etc/uwsgi/
+
+# Install Supervisord
+RUN apt-get update && apt-get install -y supervisor \
+&& rm -rf /var/lib/apt/lists/*
+# Custom Supervisord config
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Which uWSGI .ini file should be used, to make it customizable
+ENV UWSGI_INI /app/uwsgi.ini
+
+# By default, run 2 processes
+ENV UWSGI_CHEAPER 2
+
+# By default, when on demand, run up to 16 processes
+ENV UWSGI_PROCESSES 16
+
+# By default, allow unlimited file sizes, modify it to limit the file sizes
+# To have a maximum of 1 MB (Nginx's default) change the line to:
+# ENV NGINX_MAX_UPLOAD 1m
+ENV NGINX_MAX_UPLOAD 0
+
+# By default, Nginx will run a single worker process, setting it to auto
+# will create a worker for each CPU core
+ENV NGINX_WORKER_PROCESSES 1
+
+# By default, Nginx listens on port 80.
+# To modify this, change LISTEN_PORT environment variable.
+# (in a Dockerfile or with an option for `docker run`)
+ENV LISTEN_PORT 80
+
+# Copy start.sh script that will check for a /app/prestart.sh script and run it before starting the app
+COPY start.sh /start.sh
+RUN chmod +x /start.sh
+
+# Copy the entrypoint that will generate Nginx additional configs
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Add demo app
+COPY ./app /app
+WORKDIR /app
+
+# Run the start script, it will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Supervisor, which in turn will start Nginx and uWSGI
+CMD ["/start.sh"]

--- a/python3.8/app/main.py
+++ b/python3.8/app/main.py
@@ -1,0 +1,10 @@
+import sys
+
+
+def application(env, start_response):
+    version = "{}.{}".format(sys.version_info.major, sys.version_info.minor)
+    start_response("200 OK", [("Content-Type", "text/plain")])
+    message = "Hello World from a default Nginx uWSGI Python {} app in a Docker container (default)".format(
+        version
+    )
+    return [message.encode("utf-8")]

--- a/python3.8/app/prestart.sh
+++ b/python3.8/app/prestart.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env sh
+
+echo "Running inside /app/prestart.sh, you could add migrations to this file, e.g.:"
+
+echo "
+#! /usr/bin/env bash
+
+# Let the DB start
+sleep 10;
+# Run migrations
+alembic upgrade head
+"

--- a/python3.8/app/uwsgi.ini
+++ b/python3.8/app/uwsgi.ini
@@ -1,0 +1,2 @@
+[uwsgi]
+wsgi-file=/app/main.py

--- a/python3.8/entrypoint.sh
+++ b/python3.8/entrypoint.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -e
+
+# Get the maximum upload file size for Nginx, default to 0: unlimited
+USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
+
+# Get the number of workers for Nginx, default to 1
+USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
+
+# Set the max number of connections per worker for Nginx, if requested 
+# Cannot exceed worker_rlimit_nofile, see NGINX_WORKER_OPEN_FILES below
+NGINX_WORKER_CONNECTIONS=${NGINX_WORKER_CONNECTIONS:-1024}
+
+# Get the listen port for Nginx, default to 80
+USE_LISTEN_PORT=${LISTEN_PORT:-80}
+
+if [ -f /app/nginx.conf ]; then
+    cp /app/nginx.conf /etc/nginx/nginx.conf
+else
+    content='user  nginx;\n'
+    # Set the number of worker processes in Nginx
+    content=$content"worker_processes ${USE_NGINX_WORKER_PROCESSES};\n"
+    content=$content'error_log  /var/log/nginx/error.log warn;\n'
+    content=$content'pid        /var/run/nginx.pid;\n'
+    content=$content'events {\n'
+    content=$content"    worker_connections ${NGINX_WORKER_CONNECTIONS};\n"
+    content=$content'}\n'
+    content=$content'http {\n'
+    content=$content'    include       /etc/nginx/mime.types;\n'
+    content=$content'    default_type  application/octet-stream;\n'
+    content=$content'    log_format  main  '"'\$remote_addr - \$remote_user [\$time_local] \"\$request\" '\n"
+    content=$content'                      '"'\$status \$body_bytes_sent \"\$http_referer\" '\n"
+    content=$content'                      '"'\"\$http_user_agent\" \"\$http_x_forwarded_for\"';\n"
+    content=$content'    access_log  /var/log/nginx/access.log  main;\n'
+    content=$content'    sendfile        on;\n'
+    content=$content'    keepalive_timeout  65;\n'
+    content=$content'    include /etc/nginx/conf.d/*.conf;\n'
+    content=$content'}\n'
+    content=$content'daemon off;\n'
+    # Set the max number of open file descriptors for Nginx workers, if requested
+    if [ -n "${NGINX_WORKER_OPEN_FILES}" ] ; then
+        content=$content"worker_rlimit_nofile ${NGINX_WORKER_OPEN_FILES};\n"
+    fi
+    # Save generated /etc/nginx/nginx.conf
+    printf "$content" > /etc/nginx/nginx.conf
+
+    content_server='server {\n'
+    content_server=$content_server"    listen ${USE_LISTEN_PORT};\n"
+    content_server=$content_server'    location / {\n'
+    content_server=$content_server'        include uwsgi_params;\n'
+    content_server=$content_server'        uwsgi_pass unix:///tmp/uwsgi.sock;\n'
+    content_server=$content_server'    }\n'
+    content_server=$content_server'}\n'
+    # Save generated server /etc/nginx/conf.d/nginx.conf
+    printf "$content_server" > /etc/nginx/conf.d/nginx.conf
+
+    # Generate Nginx config for maximum upload file size
+    printf "client_max_body_size $USE_NGINX_MAX_UPLOAD;\n" > /etc/nginx/conf.d/upload.conf
+fi
+
+exec "$@"

--- a/python3.8/start.sh
+++ b/python3.8/start.sh
@@ -1,0 +1,15 @@
+#! /usr/bin/env sh
+set -e
+
+# If there's a prestart.sh script in the /app directory, run it before starting
+PRE_START_PATH=/app/prestart.sh
+echo "Checking for script in $PRE_START_PATH"
+if [ -f $PRE_START_PATH ] ; then
+    echo "Running script $PRE_START_PATH"
+    . $PRE_START_PATH
+else
+    echo "There is no script $PRE_START_PATH"
+fi
+
+# Start Supervisor, with Nginx and uWSGI
+exec /usr/bin/supervisord

--- a/python3.8/supervisord.conf
+++ b/python3.8/supervisord.conf
@@ -1,0 +1,18 @@
+[supervisord]
+nodaemon=true
+
+[program:uwsgi]
+command=/usr/local/bin/uwsgi --ini /etc/uwsgi/uwsgi.ini
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:nginx]
+command=/usr/sbin/nginx
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+# Graceful stop, see http://nginx.org/en/docs/control.html
+stopsignal=QUIT

--- a/python3.8/uwsgi.ini
+++ b/python3.8/uwsgi.ini
@@ -1,0 +1,10 @@
+[uwsgi]
+socket = /tmp/uwsgi.sock
+chown-socket = nginx:nginx
+chmod-socket = 664
+# Graceful shutdown on SIGTERM, see https://github.com/unbit/uwsgi/issues/849#issuecomment-118869386
+hook-master-start = unix_signal:15 gracefully_kill_them_all
+need-app = true
+die-on-term = true
+# For debugging and testing
+show-config = true


### PR DESCRIPTION
I did the following:

- Copied `python3.7` directory to `python3.8`.
- Changed mentions of `stretch` to `buster` where relevant.
- Changed `nginx` and `nginx-module-njs` versions to the latest available versions.
- Added a travis config (but I don't know much about travis).

This should fix #73 . When this is done I also plan to fix the flask version.

I tested the new build as follows:

```bash
$ docker build -t uwsgi-nginx-test python3.8
...
$ pytest tests      
================================================== test session starts ==================================================
platform darwin -- Python 3.8.1, pytest-5.3.4, py-1.8.1, pluggy-0.13.1
rootdir: /Users/dutchy/Documents/Northwave/uwsgi-nginx-docker
plugins: celery-4.4.0, mock-2.0.0, flask-sqlalchemy-1.0.2, flask-0.15.0
collected 5 items                                                                                                       

tests/test_01_main/test_defaults.py .                                                                             [ 20%]
tests/test_01_main/test_env_vars_1.py .                                                                           [ 40%]
tests/test_02_app/test_app_and_env_vars.py .                                                                      [ 60%]
tests/test_02_app/test_custom_nginx_app.py .                                                                      [ 80%]
tests/test_02_app/test_simple_app.py .                                                                            [100%]

=================================================== 5 passed in 1.43s ===================================================
```

Let me know if I missed anything.