### PR TITLE
Added ARM64 variants for Python 3.8 & 3.9

### DIFF
--- a/docker-images/python3.8-arm64.dockerfile
+++ b/docker-images/python3.8-arm64.dockerfile
@@ -1,0 +1,67 @@
+FROM arm64v8/python:3.8-buster
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+COPY install-nginx-debian.sh /
+
+RUN bash /install-nginx-debian.sh
+
+EXPOSE 80
+
+# Expose 443, in case of LTS / HTTPS
+EXPOSE 443
+
+# Install uWSGI
+RUN pip install uwsgi
+
+# Remove default configuration from Nginx
+RUN rm /etc/nginx/conf.d/default.conf
+# Copy the base uWSGI ini file to enable default dynamic uwsgi process number
+COPY uwsgi.ini /etc/uwsgi/
+
+# Install Supervisord
+RUN apt-get update && apt-get install -y supervisor \
+&& rm -rf /var/lib/apt/lists/*
+# Custom Supervisord config
+COPY supervisord-debian.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Which uWSGI .ini file should be used, to make it customizable
+ENV UWSGI_INI /app/uwsgi.ini
+
+# By default, run 2 processes
+ENV UWSGI_CHEAPER 2
+
+# By default, when on demand, run up to 16 processes
+ENV UWSGI_PROCESSES 16
+
+# By default, allow unlimited file sizes, modify it to limit the file sizes
+# To have a maximum of 1 MB (Nginx's default) change the line to:
+# ENV NGINX_MAX_UPLOAD 1m
+ENV NGINX_MAX_UPLOAD 0
+
+# By default, Nginx will run a single worker process, setting it to auto
+# will create a worker for each CPU core
+ENV NGINX_WORKER_PROCESSES 1
+
+# By default, Nginx listens on port 80.
+# To modify this, change LISTEN_PORT environment variable.
+# (in a Dockerfile or with an option for `docker run`)
+ENV LISTEN_PORT 80
+
+# Copy start.sh script that will check for a /app/prestart.sh script and run it before starting the app
+COPY start.sh /start.sh
+RUN chmod +x /start.sh
+
+# Copy the entrypoint that will generate Nginx additional configs
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Add demo app
+COPY ./app /app
+WORKDIR /app
+
+# Run the start script, it will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Supervisor, which in turn will start Nginx and uWSGI
+CMD ["/start.sh"]

--- a/docker-images/python3.9-arm64.dockerfile
+++ b/docker-images/python3.9-arm64.dockerfile
@@ -1,0 +1,67 @@
+FROM arm64v8/python:3.9-buster
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+COPY install-nginx-debian.sh /
+
+RUN bash /install-nginx-debian.sh
+
+EXPOSE 80
+
+# Expose 443, in case of LTS / HTTPS
+EXPOSE 443
+
+# Install uWSGI
+RUN pip install uwsgi
+
+# Remove default configuration from Nginx
+RUN rm /etc/nginx/conf.d/default.conf
+# Copy the base uWSGI ini file to enable default dynamic uwsgi process number
+COPY uwsgi.ini /etc/uwsgi/
+
+# Install Supervisord
+RUN apt-get update && apt-get install -y supervisor \
+&& rm -rf /var/lib/apt/lists/*
+# Custom Supervisord config
+COPY supervisord-debian.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Which uWSGI .ini file should be used, to make it customizable
+ENV UWSGI_INI /app/uwsgi.ini
+
+# By default, run 2 processes
+ENV UWSGI_CHEAPER 2
+
+# By default, when on demand, run up to 16 processes
+ENV UWSGI_PROCESSES 16
+
+# By default, allow unlimited file sizes, modify it to limit the file sizes
+# To have a maximum of 1 MB (Nginx's default) change the line to:
+# ENV NGINX_MAX_UPLOAD 1m
+ENV NGINX_MAX_UPLOAD 0
+
+# By default, Nginx will run a single worker process, setting it to auto
+# will create a worker for each CPU core
+ENV NGINX_WORKER_PROCESSES 1
+
+# By default, Nginx listens on port 80.
+# To modify this, change LISTEN_PORT environment variable.
+# (in a Dockerfile or with an option for `docker run`)
+ENV LISTEN_PORT 80
+
+# Copy start.sh script that will check for a /app/prestart.sh script and run it before starting the app
+COPY start.sh /start.sh
+RUN chmod +x /start.sh
+
+# Copy the entrypoint that will generate Nginx additional configs
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Add demo app
+COPY ./app /app
+WORKDIR /app
+
+# Run the start script, it will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Supervisor, which in turn will start Nginx and uWSGI
+CMD ["/start.sh"]

--- a/scripts/process_all.py
+++ b/scripts/process_all.py
@@ -10,6 +10,8 @@ environments = [
     {"NAME": "python3.6", "PYTHON_VERSION": "3.6"},
     {"NAME": "python2.7", "PYTHON_VERSION": "2.7"},
     {"NAME": "python3.8-alpine", "PYTHON_VERSION": "3.8"},
+    {"NAME": "python3.9-arm64", "PYTHON_VERSION": "3.9"},
+    {"NAME": "python3.8-arm64", "PYTHON_VERSION": "3.8"}
 ]
 
 start_with = os.environ.get("START_WITH")


### PR DESCRIPTION
Hey,

I was trying to use your image on my RaspberryPi, but I got an error saying that the ARM64 infrastructure is not supported.
Since I wanted to deploy my little webproject on my RaspberryPi, I quickly created the needed images on my own.

I thought it would be a neat idea, to have all possible tags in one repository/docker registry, so the life of future developers will be a bit easier :)

If you accept this pull request, I will also open one for your repository ```uwsgi-nginx-flask-docker```.

Best,
Davide