### PR TITLE
🔥 Remove support for Python 2.7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,6 @@ jobs:
             python_version: "3.7"
           - name: python3.6
             python_version: "3.6"
-          - name: python2.7
-            python_version: "2.7"
           - name: python3.8-alpine
             python_version: "3.8"
       fail-fast: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,6 @@ jobs:
             python_version: "3.7"
           - name: python3.6
             python_version: "3.6"
-          - name: python2.7
-            python_version: "2.7"
           - name: python3.8-alpine
             python_version: "3.8"
       fail-fast: true

--- a/README.md
+++ b/README.md
@@ -7,13 +7,20 @@
 * [`python3.8-alpine` _(Dockerfile)_](https://github.com/tiangolo/uwsgi-nginx-docker/blob/master/docker-images/python3.8-alpine.dockerfile)
 * [`python3.7`, _(Dockerfile)_](https://github.com/tiangolo/uwsgi-nginx-docker/blob/master/docker-images/python3.7.dockerfile)
 * [`python3.6` _(Dockerfile)_](https://github.com/tiangolo/uwsgi-nginx-docker/blob/master/docker-images/python3.6.dockerfile)
+
+## Deprecated
+
+These tags are no longer supported:
+
 * [`python2.7` _(Dockerfile)_](https://github.com/tiangolo/uwsgi-nginx-docker/blob/master/docker-images/python2.7.dockerfile)
+
+---
 
 **Note**: There are [tags for each build date](https://hub.docker.com/r/tiangolo/uwsgi-nginx/tags). If you need to "pin" the Docker image version you use, you can select one of those tags. E.g. `tiangolo/uwsgi-nginx:python3.7-2019-09-28`.
 
 # uwsgi-nginx
 
-**Docker** image with **uWSGI** and **Nginx** for web applications in **Python 3.6** and above, and **Python 2.7** (as **Flask**) in a single container. Optionally with Alpine Linux.
+**Docker** image with **uWSGI** and **Nginx** for web applications in **Python** (as **Flask**) in a single container. Optionally with Alpine Linux.
 
 ## Description
 
@@ -60,8 +67,6 @@ FROM tiangolo/uwsgi-nginx:python3.9
 
 # Your Dockerfile code...
 ```
-
-* But, if you need Python 2.7 that line would have to be `FROM tiangolo/uwsgi-nginx:python2.7`.
 
 * By default it will try to find a uWSGI config file in `/app/uwsgi.ini`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "uwsgi-nginx-docker"
 version = "0.1.0"
-description = "Docker image with uWSGI and Nginx for web applications in Python 3.6 and above and Python 2.7 (as Flask) in a single container. Optionally with Alpine Linux."
+description = "Docker image with uWSGI and Nginx for web applications in Python (as Flask) in a single container. Optionally with Alpine Linux."
 authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 license = "MIT"
 

--- a/scripts/process_all.py
+++ b/scripts/process_all.py
@@ -8,7 +8,6 @@ environments = [
     {"NAME": "python3.8", "PYTHON_VERSION": "3.8"},
     {"NAME": "python3.7", "PYTHON_VERSION": "3.7"},
     {"NAME": "python3.6", "PYTHON_VERSION": "3.6"},
-    {"NAME": "python2.7", "PYTHON_VERSION": "2.7"},
     {"NAME": "python3.8-alpine", "PYTHON_VERSION": "3.8"},
 ]
 


### PR DESCRIPTION
🔥 Remove support for Python 2.7

---

The parent image tag is not even listed in the official Python image docs: https://hub.docker.com/_/python

The latest version of the parent image was pushed a year ago: https://hub.docker.com/layers/python/library/python/2.7-buster/images/sha256-de52085267e18aba7083768f283765fcd04f753aba32cc85e62a39c77670cf4b?context=explore

And I have no particular interest in supporting Python 2.7 (I don't use it for several years ago).