### PR TITLE
🔧 Run tests only on PRs or when pushing on master to avoid double CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches:
+      - master
   pull_request:
     types: [opened, synchronize]
 


### PR DESCRIPTION
🔧 Run tests only on PRs or when pushing on master to avoid double CI