### PR TITLE
🔧 Avoid creating unnecessary `*.pyc` files with `PYTHONDONTWRITEBYTECODE=1` and ensure logs are printed immediately with `PYTHONUNBUFFERED=1`

### DIFF
--- a/docker-images/python3.10.dockerfile
+++ b/docker-images/python3.10.dockerfile
@@ -2,6 +2,9 @@ FROM python:3.10-bullseye
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
 COPY install-nginx-debian.sh /
 
 RUN bash /install-nginx-debian.sh

--- a/docker-images/python3.11.dockerfile
+++ b/docker-images/python3.11.dockerfile
@@ -2,6 +2,9 @@ FROM python:3.11-bullseye
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
 COPY install-nginx-debian.sh /
 
 RUN bash /install-nginx-debian.sh

--- a/docker-images/python3.7.dockerfile
+++ b/docker-images/python3.7.dockerfile
@@ -2,6 +2,9 @@ FROM python:3.7-bullseye
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
 COPY install-nginx-debian.sh /
 
 RUN bash /install-nginx-debian.sh

--- a/docker-images/python3.8.dockerfile
+++ b/docker-images/python3.8.dockerfile
@@ -2,6 +2,9 @@ FROM python:3.8-bullseye
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
 COPY install-nginx-debian.sh /
 
 RUN bash /install-nginx-debian.sh

--- a/docker-images/python3.9.dockerfile
+++ b/docker-images/python3.9.dockerfile
@@ -2,6 +2,9 @@ FROM python:3.9-bullseye
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
 COPY install-nginx-debian.sh /
 
 RUN bash /install-nginx-debian.sh


### PR DESCRIPTION
Added PYTHONUNBUFFERED=1 to unbuffer python logs and PYTHONDONTWRITEBYTECODE=1 to avoid create .pyc files