### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,9 @@ jobs:
       matrix:
         image:
           - name: latest
-            python_version: "3.12"
+            python_version: "3.13"
+          - name: python3.13
+            python_version: "3.13"
           - name: python3.12
             python_version: "3.12"
           - name: python3.11
@@ -49,7 +51,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             tiangolo/uwsgi-nginx:${{ matrix.image.name }}
-            tiangolo/uwsgi-nginx:${{ matrix.image.name }}-${{ env.DATE_TAG }} 
+            tiangolo/uwsgi-nginx:${{ matrix.image.name }}-${{ env.DATE_TAG }}
           context: ./docker-images/
           file: ./docker-images/${{ env.DOCKERFILE_NAME }}.dockerfile
       - name: Docker Hub Description

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,9 @@ jobs:
       matrix:
         image:
           - name: latest
-            python_version: "3.12"
+            python_version: "3.13"
+          - name: python3.13
+            python_version: "3.13"
           - name: python3.12
             python_version: "3.12"
           - name: python3.11

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## Supported tags and respective `Dockerfile` links
 
-* [`python3.12`, `latest` _(Dockerfile)_](https://github.com/tiangolo/uwsgi-nginx-docker/blob/master/docker-images/python3.12.dockerfile)
+* [`python3.13`, `latest` _(Dockerfile)_](https://github.com/tiangolo/uwsgi-nginx-docker/blob/master/docker-images/python3.13.dockerfile)
+* [`python3.12`, _(Dockerfile)_](https://github.com/tiangolo/uwsgi-nginx-docker/blob/master/docker-images/python3.12.dockerfile)
 * [`python3.11`, _(Dockerfile)_](https://github.com/tiangolo/uwsgi-nginx-docker/blob/master/docker-images/python3.11.dockerfile)
 * [`python3.10`, _(Dockerfile)_](https://github.com/tiangolo/uwsgi-nginx-docker/blob/master/docker-images/python3.10.dockerfile)
 * [`python3.9`, _(Dockerfile)_](https://github.com/tiangolo/uwsgi-nginx-docker/blob/master/docker-images/python3.9.dockerfile)

--- a/docker-images/python3.13.dockerfile
+++ b/docker-images/python3.13.dockerfile
@@ -1,0 +1,70 @@
+FROM python:3.13-bookworm
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+COPY install-nginx-debian.sh /
+
+RUN bash /install-nginx-debian.sh
+
+# Install requirements
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Remove default configuration from Nginx
+RUN rm /etc/nginx/conf.d/default.conf
+# Copy the base uWSGI ini file to enable default dynamic uwsgi process number
+COPY uwsgi.ini /etc/uwsgi/
+
+# Install Supervisord
+RUN apt-get update && apt-get install -y supervisor \
+&& rm -rf /var/lib/apt/lists/*
+# Custom Supervisord config
+COPY supervisord-debian.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Copy stop-supervisor.sh to kill the supervisor and substasks on app failure
+COPY stop-supervisor.sh /etc/supervisor/stop-supervisor.sh
+RUN chmod +x /etc/supervisor/stop-supervisor.sh
+
+# Which uWSGI .ini file should be used, to make it customizable
+ENV UWSGI_INI /app/uwsgi.ini
+
+# By default, run 2 processes
+ENV UWSGI_CHEAPER 2
+
+# By default, when on demand, run up to 16 processes
+ENV UWSGI_PROCESSES 16
+
+# By default, allow unlimited file sizes, modify it to limit the file sizes
+# To have a maximum of 1 MB (Nginx's default) change the line to:
+# ENV NGINX_MAX_UPLOAD 1m
+ENV NGINX_MAX_UPLOAD 0
+
+# By default, Nginx will run a single worker process, setting it to auto
+# will create a worker for each CPU core
+ENV NGINX_WORKER_PROCESSES 1
+
+# By default, Nginx listens on port 80.
+# To modify this, change LISTEN_PORT environment variable.
+# (in a Dockerfile or with an option for `docker run`)
+ENV LISTEN_PORT 80
+
+# Copy start.sh script that will check for a /app/prestart.sh script and run it before starting the app
+COPY start.sh /start.sh
+RUN chmod +x /start.sh
+
+# Copy the entrypoint that will generate Nginx additional configs
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Add demo app
+COPY ./app /app
+WORKDIR /app
+
+# Run the start script, it will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Supervisor, which in turn will start Nginx and uWSGI
+CMD ["/start.sh"]


### PR DESCRIPTION
♻️ Use plain python versions, no Debian bullseye tag (to get the latest), and add support for Python 3.13